### PR TITLE
Fix: Default values been nil

### DIFF
--- a/Demo/HYPForms.xcodeproj/project.pbxproj
+++ b/Demo/HYPForms.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		4445D51A19EBC78A0034A5D7 /* UIColor+HYPFormsColors.m in Sources */ = {isa = PBXBuildFile; fileRef = 4445D51619EBC78A0034A5D7 /* UIColor+HYPFormsColors.m */; };
 		4445D51B19EBC78A0034A5D7 /* UIFont+HYPFormsStyles.m in Sources */ = {isa = PBXBuildFile; fileRef = 4445D51819EBC78A0034A5D7 /* UIFont+HYPFormsStyles.m */; };
 		445DAF9619E52D76006F8052 /* ic_mini_arrow_down@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 445DAF9419E52D76006F8052 /* ic_mini_arrow_down@2x.png */; };
+		44A5C4EF1A767A8100CE46CB /* default-values.json in Resources */ = {isa = PBXBuildFile; fileRef = 44A5C4EE1A767A8100CE46CB /* default-values.json */; };
 		44BDD18D19EBD644008E9CA9 /* HYPSocialSecurityNumberValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 44BDD18919EBD644008E9CA9 /* HYPSocialSecurityNumberValidator.m */; };
 		44BDD18E19EBD644008E9CA9 /* HYPValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 44BDD18B19EBD644008E9CA9 /* HYPValidator.m */; };
 		44D5600B19EBBDA30087067E /* HYPClassFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 44D5600A19EBBDA30087067E /* HYPClassFactory.m */; };
@@ -207,6 +208,7 @@
 		4445D51719EBC78A0034A5D7 /* UIFont+HYPFormsStyles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIFont+HYPFormsStyles.h"; sourceTree = "<group>"; };
 		4445D51819EBC78A0034A5D7 /* UIFont+HYPFormsStyles.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIFont+HYPFormsStyles.m"; sourceTree = "<group>"; };
 		445DAF9419E52D76006F8052 /* ic_mini_arrow_down@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "ic_mini_arrow_down@2x.png"; sourceTree = "<group>"; };
+		44A5C4EE1A767A8100CE46CB /* default-values.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "default-values.json"; sourceTree = "<group>"; };
 		44BDD18819EBD644008E9CA9 /* HYPSocialSecurityNumberValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HYPSocialSecurityNumberValidator.h; sourceTree = "<group>"; };
 		44BDD18919EBD644008E9CA9 /* HYPSocialSecurityNumberValidator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HYPSocialSecurityNumberValidator.m; sourceTree = "<group>"; };
 		44BDD18A19EBD644008E9CA9 /* HYPValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HYPValidator.h; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 		149FC6CD1A3A516D00763456 /* JSONs */ = {
 			isa = PBXGroup;
 			children = (
+				44A5C4EE1A767A8100CE46CB /* default-values.json */,
 				14891FAB1A3E575A00EE45E0 /* field-validations.json */,
 				149FC6D01A3A553A00763456 /* multiple-show-hide-field-targets.json */,
 				149FC6CE1A3A516D00763456 /* multiple-show-hide-section-targets.json */,
@@ -661,6 +664,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				149FC6D11A3A553A00763456 /* multiple-show-hide-field-targets.json in Resources */,
+				44A5C4EF1A767A8100CE46CB /* default-values.json in Resources */,
 				14891FAC1A3E575A00EE45E0 /* field-validations.json in Resources */,
 				149FC6CF1A3A516D00763456 /* multiple-show-hide-section-targets.json in Resources */,
 			);

--- a/Demo/HYPFormsTests/HYPFormsManagerTests.m
+++ b/Demo/HYPFormsTests/HYPFormsManagerTests.m
@@ -44,12 +44,18 @@
     NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"default-values.json"
                                                              inBundle:[NSBundle bundleForClass:[self class]]];
 
+    NSDate *date = [NSDate date];
+
     HYPFormsManager *manager = [[HYPFormsManager alloc] initWithJSON:JSON
-                                                       initialValues:@{@"contract_type" : [NSNull null]}
+                                                       initialValues:@{@"contract_type" : [NSNull null],
+                                                                       @"start_date" : date,
+                                                                       @"base_salary": @2}
                                                     disabledFieldIDs:nil
                                                             disabled:NO];
 
     XCTAssertEqualObjects([manager.values objectForKey:@"contract_type"], @0);
+    XCTAssertEqualObjects([manager.values objectForKey:@"start_date"], date);
+    XCTAssertEqualObjects([manager.values objectForKey:@"base_salary"], @2);
 }
 
 - (void)testFormsGenerationHideTargets

--- a/Demo/HYPFormsTests/HYPFormsManagerTests.m
+++ b/Demo/HYPFormsTests/HYPFormsManagerTests.m
@@ -21,7 +21,7 @@
 
 @implementation HYPFormsManagerTests
 
-- (void)testFormsGenerationOnlyJSON
+- (void)testFormsGeneration
 {
     NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"forms.json"];
 
@@ -37,6 +37,19 @@
     XCTAssertTrue(manager.hiddenFieldsAndFieldIDsDictionary.count == 0);
 
     XCTAssertTrue(manager.hiddenSections.count == 0);
+}
+
+- (void)testDefaultValues
+{
+    NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"default-values.json"
+                                                             inBundle:[NSBundle bundleForClass:[self class]]];
+
+    HYPFormsManager *manager = [[HYPFormsManager alloc] initWithJSON:JSON
+                                                       initialValues:@{@"contract_type" : [NSNull null]}
+                                                    disabledFieldIDs:nil
+                                                            disabled:NO];
+
+    XCTAssertEqualObjects([manager.values objectForKey:@"contract_type"], @0);
 }
 
 - (void)testFormsGenerationHideTargets

--- a/Demo/HYPFormsTests/JSONs/default-values.json
+++ b/Demo/HYPFormsTests/JSONs/default-values.json
@@ -25,6 +25,41 @@
                 "title":"Temporary"
               }
             ]
+          },
+          {
+            "id":"start_date",
+            "title":"Start date",
+            "type":"date",
+            "size":{
+              "width":25,
+              "height":1
+            }
+          },
+          {
+            "id":"base_salary",
+            "title":"Base salary",
+            "type":"select",
+            "size":{
+              "width":25,
+              "height":1
+            },
+            "values":[
+              {
+                "title":"Salary 1",
+                "id":0,
+                "value":100.0
+              },
+              {
+                "title":"Salary 2",
+                "id":1,
+                "value":200.0
+              },
+              {
+                "title":"Salary 3",
+                "id":2,
+                "value":10.0
+              }
+            ]
           }
         ]
       }

--- a/Demo/HYPFormsTests/JSONs/default-values.json
+++ b/Demo/HYPFormsTests/JSONs/default-values.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id":"employment",
+    "title":"Employment",
+    "sections":[
+      {
+        "id":"employment-0",
+        "fields":[
+          {
+            "id":"contract_type",
+            "title":"Contract type",
+            "type":"select",
+            "size":{
+              "width":50,
+              "height":1
+            },
+            "values":[
+              {
+                "id":0,
+                "title":"Permanent",
+                "default":true
+              },
+              {
+                "id":1,
+                "title":"Temporary"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/Source/HYPFormsManager.m
+++ b/Source/HYPFormsManager.m
@@ -34,6 +34,8 @@
     _disabledFieldsIDs = disabledFieldIDs;
     _disabled = disabled;
 
+    [self.values addEntriesFromDictionary:initialValues];
+
     [self generateFormsWithJSON:JSON
                   initialValues:initialValues
               disabledFieldsIDs:disabledFieldIDs
@@ -168,8 +170,6 @@
 
         [self.forms addObject:form];
     }];
-
-    [self.values addEntriesFromDictionary:initialValues];
 
     for (HYPFormTarget *target in targetsToRun) {
         if (![self evaluateCondition:target.condition]) continue;


### PR DESCRIPTION
This fixes a bug that caused `default` values been overwritten when initial values contained `NSNull`. See first commit of failing test for more info.