### PR TITLE
Remove collection view batch update

### DIFF
--- a/Source/HYPFormsCollectionViewDataSource.m
+++ b/Source/HYPFormsCollectionViewDataSource.m
@@ -378,12 +378,6 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
     }];
 
     [self processTargets:targets];
-
-    if (updatedIndexPaths.count > 0) {
-        [self.collectionView performBatchUpdates:^{
-            [self reloadItemsAtIndexPaths:updatedIndexPaths];
-        } completion:nil];
-    }
 }
 
 - (HYPFormField *)fieldInDeletedFields:(NSString *)fieldID


### PR DESCRIPTION
This caused the app to crash if you try to reload the form with a dictionary and the count of index paths are out for sync. If the current state has more fields than what the reload outcome has.

```Terminating app due to uncaught exception
'NSInternalInconsistencyException', reason: 'attempt to delete item 19
from section 1 which only contains 17 items before the update'```

This fixes that issue and I haven’t seen any side effects from removing
this.