### PR TITLE
Improve enable/disable API

### DIFF
--- a/HYPForms.podspec
+++ b/HYPForms.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "HYPForms"
-  s.version = "0.100"
+  s.version = "0.102"
   s.summary = "JSON driven forms"
   s.description = <<-DESC
                    * JSON driven forms

--- a/Source/HYPFormsCollectionViewDataSource.m
+++ b/Source/HYPFormsCollectionViewDataSource.m
@@ -295,7 +295,12 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
 - (void)disable:(BOOL)disabled
 {
     self.disabled = disabled;
-    self.formsManager.disabled = disabled;
+
+    if (disabled) {
+        [self.formsManager disable];
+    } else {
+        [self.formsManager enable];
+    }
 
     NSMutableDictionary *fields = [NSMutableDictionary new];
 
@@ -510,7 +515,7 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
             [self reloadItemsAtIndexPaths:updatedIndexPaths];
         } break;
         case HYPFormTargetActionEnable: {
-            if (!self.formsManager.disabled) {
+            if ([self.formsManager isEnabled]) {
                 NSArray *enabledIndexPaths = [self.formsManager enableTargets:@[target]];
                 [self reloadItemsAtIndexPaths:enabledIndexPaths];
             }
@@ -575,7 +580,7 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
                                   }
                               }
 
-                              BOOL shouldRunEnableTargets = (enabledTargets.count > 0 && !self.formsManager.disabled);
+                              BOOL shouldRunEnableTargets = (enabledTargets.count > 0 && [self.formsManager isEnabled]);
                               if (shouldRunEnableTargets) {
                                   enabledIndexPaths = [self.formsManager enableTargets:enabledTargets];
 

--- a/Source/HYPFormsManager.h
+++ b/Source/HYPFormsManager.h
@@ -9,7 +9,6 @@
 @property (nonatomic, strong) NSMutableDictionary *hiddenSections;
 @property (nonatomic, strong) NSArray *disabledFieldsIDs;
 @property (nonatomic, strong) NSMutableDictionary *values;
-@property (nonatomic) BOOL disabled;
 
 - (instancetype)initWithJSON:(id)JSON
                initialValues:(NSDictionary *)initialValues
@@ -41,5 +40,13 @@
 - (NSArray *)updateTargets:(NSArray *)targets;
 - (NSArray *)enableTargets:(NSArray *)targets;
 - (NSArray *)disableTargets:(NSArray *)targets;
+
+- (void)disable;
+
+- (void)enable;
+
+- (BOOL)isDisabled;
+
+- (BOOL)isEnabled;
 
 @end

--- a/Source/HYPFormsManager.m
+++ b/Source/HYPFormsManager.m
@@ -18,6 +18,7 @@
 
 @property (nonatomic, strong) NSMutableDictionary *requiredFields;
 @property (nonatomic, strong) DDMathEvaluator *evaluator;
+@property (nonatomic) BOOL disabledForm;
 
 @end
 
@@ -32,7 +33,7 @@
     if (!self) return nil;
 
     _disabledFieldsIDs = disabledFieldIDs;
-    _disabled = disabled;
+    _disabledForm = disabled;
 
     [self.values addEntriesFromDictionary:initialValues];
 
@@ -753,6 +754,28 @@
     }
 
     return evaluatedResult;
+}
+
+#pragma mark - Enable/Disable
+
+- (void)disable
+{
+    self.disabledForm = YES;
+}
+
+- (void)enable
+{
+    self.disabledForm = NO;
+}
+
+- (BOOL)isDisabled
+{
+    return self.disabledForm;
+}
+
+- (BOOL)isEnabled
+{
+    return !self.disabledForm;
 }
 
 @end


### PR DESCRIPTION
Having mutating booleans is usually dangerous and hard to read as API.

I believe `if ([form isEnabled])` is better than `if (!form.disable)`