### PR TITLE
Remove NSNull values from evaluateExpression

### DIFF
--- a/Source/HYPFormsManager.m
+++ b/Source/HYPFormsManager.m
@@ -743,10 +743,18 @@
 
     if (condition) {
         NSError *error;
+
+        NSSet *set = [self.values keysOfEntriesPassingTest:^BOOL(id key, id obj, BOOL *stop) {
+            return [obj isEqual:[NSNull null]];
+        }];
+
+        NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithDictionary:self.values];
+        [dictionary removeObjectsForKeys:[set allObjects]];
+
         DDExpression *expression = [DDExpression expressionFromString:condition error:&error];
         if (error == nil && self.values) {
             NSNumber *result = [self.evaluator evaluateExpression:expression
-                                                withSubstitutions:self.values
+                                                withSubstitutions:dictionary
                                                             error:&error];
             return [result boolValue];
         }


### PR DESCRIPTION
This caused a crash in many places, better not send them, DDExpression
doesn’t play nice with them.