### PR TITLE
Simplify HYPFormsCollectionViewDataSource initialization

### DIFF
--- a/Demo/HYPForms/HYPSampleCollectionViewController.m
+++ b/Demo/HYPForms/HYPSampleCollectionViewController.m
@@ -35,6 +35,13 @@
     self.layout = layout;
     self.initialValues = dictionary;
 
+    [self.collectionView registerClass:[HYPImageFormFieldCell class]
+            forCellWithReuseIdentifier:HYPImageFormFieldCellIdentifier];
+
+    self.collectionView.dataSource = self.dataSource;
+
+    NSLog(@"Initializated with %ld sections", (long)[self.collectionView numberOfSections]);
+
     return self;
 }
 
@@ -59,8 +66,8 @@
     if (_dataSource) return _dataSource;
 
     _dataSource = [[HYPFormsCollectionViewDataSource alloc] initWithCollectionView:self.collectionView
+                                                                            layout:self.layout
                                                                    andFormsManager:self.formsManager];
-    self.layout.dataSource = _dataSource;
 
     _dataSource.configureCellForIndexPath = ^(HYPFormField *field, UICollectionView *collectionView, NSIndexPath *indexPath) {
         BOOL isImageCell = (field.type == HYPFormFieldTypeCustom && [field.typeString isEqual:@"image"]);
@@ -114,12 +121,6 @@
     self.collectionView.contentInset = UIEdgeInsetsMake(20.0f, 0.0f, 0.0f, 0.0f);
 
     self.collectionView.backgroundColor = [UIColor HYPFormsBackground];
-
-    [self.collectionView registerClass:[HYPImageFormFieldCell class]
-            forCellWithReuseIdentifier:HYPImageFormFieldCellIdentifier];
-
-    self.collectionView.delegate = self;
-    self.collectionView.dataSource = self.dataSource;
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -160,8 +161,6 @@
     [self setToolbarItems:@[validateButtonItem, flexibleBarButtonItem, updateButtonItem, flexibleBarButtonItem, readOnlyBarButtonItem]];
 
     [self.navigationController setToolbarHidden:NO animated:YES];
-
-    [self.dataSource processTarget:[HYPFormTarget hideFieldTargetWithID:@"image"]];
 }
 
 #pragma mark - UICollectionViewDelegate
@@ -244,9 +243,9 @@
     HYPFormTarget *target;
 
     if (sender.isOn) {
-        target = [HYPFormTarget hideFieldTargetWithID:@"image"];
+        target = [HYPFormTarget disableFieldTargetWithID:@"image"];
     } else {
-        target = [HYPFormTarget showFieldTargetWithID:@"image"];
+        target = [HYPFormTarget enableFieldTargetWithID:@"image"];
     }
 
     [self.dataSource processTargets:@[target]];

--- a/Demo/HYPForms/HYPSampleCollectionViewController.m
+++ b/Demo/HYPForms/HYPSampleCollectionViewController.m
@@ -58,7 +58,8 @@
     _dataSource = [[HYPFormsCollectionViewDataSource alloc] initWithJSON:JSON
                                                           collectionView:self.collectionView
                                                                   layout:self.layout
-                                                                  values:self.initialValues];
+                                                                  values:self.initialValues
+                                                                disabled:YES];
 
     _dataSource.configureCellForIndexPath = ^(HYPFormField *field, UICollectionView *collectionView, NSIndexPath *indexPath) {
         id cell;

--- a/Demo/HYPForms/HYPSampleCollectionViewController.m
+++ b/Demo/HYPForms/HYPSampleCollectionViewController.m
@@ -12,8 +12,7 @@
 #import "NSJSONSerialization+ANDYJSONFile.h"
 #import "UIColor+HYPFormsColors.h"
 
-@interface HYPSampleCollectionViewController () <HYPImagePickerDelegate,
-HYPFormsCollectionViewDataSourceDataSource>
+@interface HYPSampleCollectionViewController () <HYPImagePickerDelegate>
 
 @property (nonatomic, strong) HYPFormsCollectionViewDataSource *dataSource;
 @property (nonatomic, copy) NSDictionary *initialValues;
@@ -61,10 +60,17 @@ HYPFormsCollectionViewDataSourceDataSource>
 
     _dataSource = [[HYPFormsCollectionViewDataSource alloc] initWithCollectionView:self.collectionView
                                                                    andFormsManager:self.formsManager];
-
-    self.collectionView.dataSource = _dataSource;
     self.layout.dataSource = _dataSource;
-    _dataSource.dataSource = self;
+
+    _dataSource.configureCellForIndexPath = ^(HYPFormField *field, UICollectionView *collectionView, NSIndexPath *indexPath) {
+        BOOL isImageCell = (field.type == HYPFormFieldTypeCustom && [field.typeString isEqual:@"image"]);
+        id cell;
+        if (isImageCell) {
+            cell = [collectionView dequeueReusableCellWithReuseIdentifier:HYPImageFormFieldCellIdentifier
+                                                             forIndexPath:indexPath];
+        }
+        return cell;
+    };
 
     __weak typeof(self)weakSelf = self;
 
@@ -244,23 +250,6 @@ HYPFormsCollectionViewDataSourceDataSource>
     }
 
     [self.dataSource processTargets:@[target]];
-}
-
-#pragma mark - HYPFormsCollectionViewDataSourceDataSource
-
-- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
-               formsCollectionDataSource:(HYPFormsCollectionViewDataSource *)formsCollectionDataSource
-                            cellForField:(HYPFormField *)field atIndexPath:(NSIndexPath *)indexPath
-{
-    HYPImageFormFieldCell *cell;
-
-    BOOL isImageCell = (field.type == HYPFormFieldTypeCustom && [field.typeString isEqual:@"image"]);
-    if (isImageCell) {
-        cell = [collectionView dequeueReusableCellWithReuseIdentifier:HYPImageFormFieldCellIdentifier
-                                                         forIndexPath:indexPath];
-    }
-
-    return cell;
 }
 
 @end

--- a/Demo/HYPForms/HYPSampleCollectionViewController.m
+++ b/Demo/HYPForms/HYPSampleCollectionViewController.m
@@ -18,7 +18,6 @@
 @property (nonatomic, strong) HYPFormsCollectionViewDataSource *dataSource;
 @property (nonatomic, copy) NSDictionary *initialValues;
 @property (nonatomic, strong) HYPImagePicker *imagePicker;
-@property (nonatomic, strong) HYPFormsManager *formsManager;
 @property (nonatomic, strong) HYPFormsLayout *layout;
 
 @end
@@ -50,27 +49,16 @@
 
 #pragma mark - Getters
 
-- (HYPFormsManager *)formsManager
-{
-    if (_formsManager) return _formsManager;
-
-    NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"forms.json"];
-
-    _formsManager = [[HYPFormsManager alloc] initWithJSON:JSON
-                                            initialValues:self.initialValues
-                                         disabledFieldIDs:@[@"display_name"]
-                                                 disabled:YES];
-
-    return _formsManager;
-}
-
 - (HYPFormsCollectionViewDataSource *)dataSource
 {
     if (_dataSource) return _dataSource;
 
-    _dataSource = [[HYPFormsCollectionViewDataSource alloc] initWithCollectionView:self.collectionView
-                                                                            layout:self.layout
-                                                                   andFormsManager:self.formsManager];
+    NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"forms.json"];
+
+    _dataSource = [[HYPFormsCollectionViewDataSource alloc] initWithJSON:JSON
+                                                          collectionView:self.collectionView
+                                                                  layout:self.layout
+                                                                  values:self.initialValues];
 
     _dataSource.configureCellForIndexPath = ^(HYPFormField *field, UICollectionView *collectionView, NSIndexPath *indexPath) {
         BOOL isImageCell = (field.type == HYPFormFieldTypeCustom && [field.typeString isEqual:@"image"]);
@@ -90,7 +78,7 @@
         BOOL shouldUpdateStartDate = ([field.fieldID isEqualToString:@"contract_type"]);
 
         if (shouldUpdateStartDate) {
-            [weakSelf.formsManager fieldWithID:@"start_date" includingHiddenFields:YES completion:^(HYPFormField *field, NSIndexPath *indexPath) {
+            [weakSelf.dataSource.formsManager fieldWithID:@"start_date" includingHiddenFields:YES completion:^(HYPFormField *field, NSIndexPath *indexPath) {
                 if (field) {
                     field.fieldValue = [NSDate date];
                     field.minimumDate = [NSDate date];

--- a/Demo/HYPForms/HYPSampleCollectionViewController.m
+++ b/Demo/HYPForms/HYPSampleCollectionViewController.m
@@ -61,8 +61,8 @@
                                                                   values:self.initialValues];
 
     _dataSource.configureCellForIndexPath = ^(HYPFormField *field, UICollectionView *collectionView, NSIndexPath *indexPath) {
-        BOOL isImageCell = (field.type == HYPFormFieldTypeCustom && [field.typeString isEqual:@"image"]);
         id cell;
+        BOOL isImageCell = (field.type == HYPFormFieldTypeCustom && [field.typeString isEqual:@"image"]);
         if (isImageCell) {
             cell = [collectionView dequeueReusableCellWithReuseIdentifier:HYPImageFormFieldCellIdentifier
                                                              forIndexPath:indexPath];

--- a/Demo/HYPForms/HYPSampleCollectionViewController.m
+++ b/Demo/HYPForms/HYPSampleCollectionViewController.m
@@ -13,12 +13,13 @@
 #import "UIColor+HYPFormsColors.h"
 
 @interface HYPSampleCollectionViewController () <HYPImagePickerDelegate,
-HYPFormsCollectionViewDataSourceDataSource, HYPFormsLayoutDataSource>
+HYPFormsCollectionViewDataSourceDataSource>
 
 @property (nonatomic, strong) HYPFormsCollectionViewDataSource *dataSource;
 @property (nonatomic, copy) NSDictionary *initialValues;
 @property (nonatomic, strong) HYPImagePicker *imagePicker;
 @property (nonatomic, strong) HYPFormsManager *formsManager;
+@property (nonatomic, strong) HYPFormsLayout *layout;
 
 @end
 
@@ -29,11 +30,10 @@ HYPFormsCollectionViewDataSourceDataSource, HYPFormsLayoutDataSource>
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
     HYPFormsLayout *layout = [[HYPFormsLayout alloc] init];
-
     self = [super initWithCollectionViewLayout:layout];
     if (!self) return nil;
 
-    layout.dataSource = self;
+    self.layout = layout;
     self.initialValues = dictionary;
 
     return self;
@@ -62,6 +62,8 @@ HYPFormsCollectionViewDataSourceDataSource, HYPFormsLayoutDataSource>
     _dataSource = [[HYPFormsCollectionViewDataSource alloc] initWithCollectionView:self.collectionView
                                                                    andFormsManager:self.formsManager];
 
+    self.collectionView.dataSource = _dataSource;
+    self.layout.dataSource = _dataSource;
     _dataSource.dataSource = self;
 
     __weak typeof(self)weakSelf = self;
@@ -258,18 +260,6 @@ HYPFormsCollectionViewDataSourceDataSource, HYPFormsLayoutDataSource>
     }
 
     return cell;
-}
-
-#pragma mark - HYPFormsLayoutDataSource
-
-- (NSArray *)forms
-{
-    return self.formsManager.forms;
-}
-
-- (NSArray *)collapsedForms
-{
-    return self.dataSource.collapsedForms;
 }
 
 @end

--- a/Demo/HYPForms/HYPSampleCollectionViewController.m
+++ b/Demo/HYPForms/HYPSampleCollectionViewController.m
@@ -11,6 +11,7 @@
 #import "UIColor+ANDYHex.h"
 #import "NSJSONSerialization+ANDYJSONFile.h"
 #import "UIColor+HYPFormsColors.h"
+#import "NSObject+HYPTesting.h"
 
 @interface HYPSampleCollectionViewController () <HYPImagePickerDelegate>
 
@@ -40,7 +41,9 @@
 
     self.collectionView.dataSource = self.dataSource;
 
-    NSLog(@"Initializated with %ld sections", (long)[self.collectionView numberOfSections]);
+    if ([NSObject isUnitTesting]) {
+        [self.collectionView numberOfSections];
+    }
 
     return self;
 }

--- a/Demo/HYPForms/HYPSampleCollectionViewController.m
+++ b/Demo/HYPForms/HYPSampleCollectionViewController.m
@@ -248,15 +248,16 @@ HYPFormsCollectionViewDataSourceDataSource>
 
 #pragma mark - HYPFormsCollectionViewDataSourceDataSource
 
-- (UICollectionViewCell *)formsCollectionDataSource:(HYPFormsCollectionViewDataSource *)formsCollectionDataSource
-                                       cellForField:(HYPFormField *)field atIndexPath:(NSIndexPath *)indexPath
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
+               formsCollectionDataSource:(HYPFormsCollectionViewDataSource *)formsCollectionDataSource
+                            cellForField:(HYPFormField *)field atIndexPath:(NSIndexPath *)indexPath
 {
     HYPImageFormFieldCell *cell;
 
     BOOL isImageCell = (field.type == HYPFormFieldTypeCustom && [field.typeString isEqual:@"image"]);
     if (isImageCell) {
-        cell = [self.collectionView dequeueReusableCellWithReuseIdentifier:HYPImageFormFieldCellIdentifier
-                                                              forIndexPath:indexPath];
+        cell = [collectionView dequeueReusableCellWithReuseIdentifier:HYPImageFormFieldCellIdentifier
+                                                         forIndexPath:indexPath];
     }
 
     return cell;

--- a/Demo/HYPFormsTests/HYPFormFieldTests.m
+++ b/Demo/HYPFormsTests/HYPFormFieldTests.m
@@ -9,41 +9,9 @@
 
 @interface HYPFormFieldTests : XCTestCase
 
-@property (nonatomic, strong) HYPFormsManager *manager;
-@property (nonatomic, strong) HYPFormsCollectionViewDataSource *dataSource;
-
 @end
 
 @implementation HYPFormFieldTests
-
-- (void)setUp
-{
-    [super setUp];
-
-    HYPFormsLayout *layout = [[HYPFormsLayout alloc] init];
-
-    UICollectionView *collectionView = [[UICollectionView alloc] initWithFrame:[[UIScreen mainScreen] bounds]
-                                                          collectionViewLayout:layout];
-
-    NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"forms.json"];
-
-    self.manager = [[HYPFormsManager alloc] initWithJSON:JSON
-                                           initialValues:nil
-                                        disabledFieldIDs:nil
-                                                disabled:NO];
-
-    self.dataSource = [[HYPFormsCollectionViewDataSource alloc] initWithCollectionView:collectionView
-                                                                                layout:layout
-                                                                       andFormsManager:self.manager];
-}
-
-- (void)tearDown
-{
-    self.manager = nil;
-    self.dataSource = nil;
-
-    [super tearDown];
-}
 
 - (void)testInitWithDictionary
 {

--- a/Demo/HYPFormsTests/HYPFormFieldTests.m
+++ b/Demo/HYPFormsTests/HYPFormFieldTests.m
@@ -7,7 +7,7 @@
 #import "HYPFormsCollectionViewDataSource.h"
 #import "NSJSONSerialization+ANDYJSONFile.h"
 
-@interface HYPFormFieldTests : XCTestCase <HYPFormsLayoutDataSource>
+@interface HYPFormFieldTests : XCTestCase
 
 @property (nonatomic, strong) HYPFormsManager *manager;
 @property (nonatomic, strong) HYPFormsCollectionViewDataSource *dataSource;
@@ -21,7 +21,6 @@
     [super setUp];
 
     HYPFormsLayout *layout = [[HYPFormsLayout alloc] init];
-    layout.dataSource = self;
 
     UICollectionView *collectionView = [[UICollectionView alloc] initWithFrame:[[UIScreen mainScreen] bounds]
                                                           collectionViewLayout:layout];
@@ -34,6 +33,7 @@
                                                 disabled:NO];
 
     self.dataSource = [[HYPFormsCollectionViewDataSource alloc] initWithCollectionView:collectionView
+                                                                                layout:layout
                                                                        andFormsManager:self.manager];
 }
 
@@ -112,18 +112,6 @@
     field = [manager fieldWithID:@"first_name" includingHiddenFields:YES];
 
     XCTAssertNil(field);
-}
-
-#pragma mark - HYPFormsLayoutDataSource
-
-- (NSArray *)forms
-{
-    return self.manager.forms;
-}
-
-- (NSArray *)collapsedForms
-{
-    return self.dataSource.collapsedForms;
 }
 
 @end

--- a/Demo/HYPFormsTests/HYPFormsCollectionViewDataSourceTests.m
+++ b/Demo/HYPFormsTests/HYPFormsCollectionViewDataSourceTests.m
@@ -9,141 +9,124 @@
 #import "HYPFormsManager.h"
 #import "HYPFormTarget.h"
 #import "HYPImageFormFieldCell.h"
+#import "HYPSampleCollectionViewController.h"
 
 #import "NSJSONSerialization+ANDYJSONFile.h"
 
-@interface HYPFormsCollectionViewDataSourceTests : XCTestCase
+@interface HYPSampleCollectionViewController ()
 
-@property (nonatomic, strong) HYPFormsManager *manager;
 @property (nonatomic, strong) HYPFormsCollectionViewDataSource *dataSource;
+@property (nonatomic, strong) HYPFormsManager *formsManager;
+
+@end
+
+@interface HYPFormsCollectionViewDataSourceTests : XCTestCase
 
 @end
 
 @implementation HYPFormsCollectionViewDataSourceTests
 
-- (void)setUp
+- (HYPSampleCollectionViewController *)controller
 {
-    [super setUp];
+    HYPSampleCollectionViewController *controller = [[HYPSampleCollectionViewController alloc] initWithDictionary:@{}];
 
-    HYPFormsLayout *layout = [[HYPFormsLayout alloc] init];
-
-    UICollectionView *collectionView = [[UICollectionView alloc] initWithFrame:[[UIScreen mainScreen] bounds]
-                                                          collectionViewLayout:layout];
-
-    [collectionView registerClass:[HYPImageFormFieldCell class]
-       forCellWithReuseIdentifier:HYPImageFormFieldCellIdentifier];
-
-    NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"forms.json"];
-
-    self.manager = [[HYPFormsManager alloc] initWithJSON:JSON
-                                           initialValues:nil
-                                        disabledFieldIDs:nil
-                                                disabled:NO];
-
-    self.dataSource = [[HYPFormsCollectionViewDataSource alloc] initWithCollectionView:collectionView
-                                                                       andFormsManager:self.manager];
-    layout.dataSource = self.dataSource;
-
-    self.dataSource.configureCellForIndexPath = ^(HYPFormField *field, UICollectionView *collectionView, NSIndexPath *indexPath) {
-        BOOL isImageCell = (field.type == HYPFormFieldTypeCustom && [field.typeString isEqual:@"image"]);
-        id cell;
-        if (isImageCell) {
-            cell = [collectionView dequeueReusableCellWithReuseIdentifier:HYPImageFormFieldCellIdentifier
-                                                             forIndexPath:indexPath];
-        }
-        return cell;
-    };
-}
-
-- (void)tearDown
-{
-    self.manager = nil;
-    self.dataSource = nil;
-
-    [super tearDown];
+    return controller;
 }
 
 - (void)testIndexInForms
 {
-    [self.dataSource processTarget:[HYPFormTarget hideFieldTargetWithID:@"display_name"]];
-    [self.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"display_name"]];
-    HYPFormField *field = [self.manager fieldWithID:@"display_name" includingHiddenFields:YES];
-    NSUInteger index = [field indexInSectionUsingForms:self.manager.forms];
+    HYPSampleCollectionViewController *controller = [self controller];
+
+    [controller.dataSource processTarget:[HYPFormTarget hideFieldTargetWithID:@"display_name"]];
+    [controller.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"display_name"]];
+    HYPFormField *field = [controller.formsManager fieldWithID:@"display_name" includingHiddenFields:YES];
+    NSUInteger index = [field indexInSectionUsingForms:controller.formsManager.forms];
     XCTAssertEqual(index, 2);
 
-    [self.dataSource processTarget:[HYPFormTarget hideFieldTargetWithID:@"username"]];
-    [self.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"username"]];
-    field = [self.manager fieldWithID:@"username" includingHiddenFields:YES];
-    index = [field indexInSectionUsingForms:self.manager.forms];
+    [controller.dataSource processTarget:[HYPFormTarget hideFieldTargetWithID:@"username"]];
+    [controller.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"username"]];
+    field = [controller.formsManager fieldWithID:@"username" includingHiddenFields:YES];
+    index = [field indexInSectionUsingForms:controller.formsManager.forms];
     XCTAssertEqual(index, 2);
 
-    [self.dataSource processTargets:[HYPFormTarget hideFieldTargetsWithIDs:@[@"first_name",
+    [controller.dataSource processTargets:[HYPFormTarget hideFieldTargetsWithIDs:@[@"first_name",
                                                                              @"address",
                                                                              @"username"]]];
-    [self.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"username"]];
-    field = [self.manager fieldWithID:@"username" includingHiddenFields:YES];
-    index = [field indexInSectionUsingForms:self.manager.forms];
+    [controller.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"username"]];
+    field = [controller.formsManager fieldWithID:@"username" includingHiddenFields:YES];
+    index = [field indexInSectionUsingForms:controller.formsManager.forms];
     XCTAssertEqual(index, 1);
-    [self.dataSource processTargets:[HYPFormTarget showFieldTargetsWithIDs:@[@"first_name",
+    [controller.dataSource processTargets:[HYPFormTarget showFieldTargetsWithIDs:@[@"first_name",
                                                                              @"address"]]];
 
-    [self.dataSource processTargets:[HYPFormTarget hideFieldTargetsWithIDs:@[@"last_name",
+    [controller.dataSource processTargets:[HYPFormTarget hideFieldTargetsWithIDs:@[@"last_name",
                                                                              @"address"]]];
-    [self.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"address"]];
-    field = [self.manager fieldWithID:@"address" includingHiddenFields:YES];
-    index = [field indexInSectionUsingForms:self.manager.forms];
+    [controller.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"address"]];
+    field = [controller.formsManager fieldWithID:@"address" includingHiddenFields:YES];
+    index = [field indexInSectionUsingForms:controller.formsManager.forms];
     XCTAssertEqual(index, 0);
-    [self.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"last_name"]];
+    [controller.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"last_name"]];
 }
 
 - (void)testEnableAndDisableTargets
 {
-    HYPFormField *targetField = [self.manager fieldWithID:@"base_salary" includingHiddenFields:YES];
+    HYPSampleCollectionViewController *controller = [self controller];
+    [controller.dataSource enable];
+
+    HYPFormField *targetField = [controller.formsManager fieldWithID:@"base_salary" includingHiddenFields:YES];
     XCTAssertFalse(targetField.isDisabled);
 
     HYPFormTarget *disableTarget = [HYPFormTarget disableFieldTargetWithID:@"base_salary"];
-    [self.dataSource processTarget:disableTarget];
+    [controller.dataSource processTarget:disableTarget];
     XCTAssertTrue(targetField.isDisabled);
 
     HYPFormTarget *enableTarget = [HYPFormTarget enableFieldTargetWithID:@"base_salary"];
-    [self.dataSource processTargets:@[enableTarget]];
+    [controller.dataSource processTargets:@[enableTarget]];
     XCTAssertFalse(targetField.isDisabled);
 
-    [self.dataSource disable];
+    [controller.dataSource disable];
     XCTAssertTrue(targetField.isDisabled);
 
-    [self.dataSource enable];
+    [controller.dataSource enable];
     XCTAssertFalse(targetField.isDisabled);
 }
 
 - (void)testInitiallyDisabled
 {
-    HYPFormField *totalField = [self.manager fieldWithID:@"total" includingHiddenFields:YES];
+    HYPSampleCollectionViewController *controller = [self controller];
+
+    HYPFormField *totalField = [controller.formsManager fieldWithID:@"total" includingHiddenFields:YES];
     XCTAssertTrue(totalField.disabled);
 }
 
 - (void)testUpdatingTargetValue
 {
-    HYPFormField *targetField = [self.manager fieldWithID:@"display_name" includingHiddenFields:YES];
+    HYPSampleCollectionViewController *controller = [self controller];
+
+    HYPFormField *targetField = [controller.formsManager fieldWithID:@"display_name" includingHiddenFields:YES];
     XCTAssertNil(targetField.fieldValue);
 
     HYPFormTarget *updateTarget = [HYPFormTarget updateFieldTargetWithID:@"display_name"];
     updateTarget.targetValue = @"John Hyperseed";
 
-    [self.dataSource processTarget:updateTarget];
+    [controller.dataSource processTarget:updateTarget];
     XCTAssertEqualObjects(targetField.fieldValue, @"John Hyperseed");
 }
 
 - (void)testDefaultValue
 {
-    HYPFormField *usernameField = [self.manager fieldWithID:@"username" includingHiddenFields:YES];
+    HYPSampleCollectionViewController *controller = [self controller];
+
+    HYPFormField *usernameField = [controller.formsManager fieldWithID:@"username" includingHiddenFields:YES];
     XCTAssertNotNil(usernameField.fieldValue);
 }
 
 - (void)testCondition
 {
-    HYPFormField *displayNameField = [self.manager fieldWithID:@"display_name" includingHiddenFields:YES];
-    HYPFormField *usernameField = [self.manager fieldWithID:@"username" includingHiddenFields:YES];
+    HYPSampleCollectionViewController *controller = [self controller];
+
+    HYPFormField *displayNameField = [controller.formsManager fieldWithID:@"display_name" includingHiddenFields:YES];
+    HYPFormField *usernameField = [controller.formsManager fieldWithID:@"username" includingHiddenFields:YES];
     HYPFieldValue *fieldValue = usernameField.fieldValue;
     XCTAssertEqualObjects(fieldValue.valueID, @0);
 
@@ -151,33 +134,37 @@
     updateTarget.targetValue = @"Mr.Melk";
 
     updateTarget.condition = @"$username == 2";
-    [self.dataSource processTarget:updateTarget];
+    [controller.dataSource processTarget:updateTarget];
     XCTAssertNil(displayNameField.fieldValue);
 
     updateTarget.condition = @"$username == 0";
-    [self.dataSource processTarget:updateTarget];
+    [controller.dataSource processTarget:updateTarget];
     XCTAssertEqualObjects(displayNameField.fieldValue, @"Mr.Melk");
 }
 
 - (void)testReloadWithDictionary
 {
-    [self.dataSource reloadWithDictionary:@{@"first_name" : @"Elvis",
+    HYPSampleCollectionViewController *controller = [self controller];
+
+    [controller.dataSource reloadWithDictionary:@{@"first_name" : @"Elvis",
                                             @"last_name" : @"Nunez"}];
 
-    HYPFormField *field = [self.manager fieldWithID:@"display_name" includingHiddenFields:YES];
+    HYPFormField *field = [controller.formsManager fieldWithID:@"display_name" includingHiddenFields:YES];
     XCTAssertEqualObjects(field.fieldValue, @"Elvis Nunez");
 }
 
 - (void)testClearTarget
 {
-    HYPFormField *firstNameField = [self.manager fieldWithID:@"first_name" includingHiddenFields:YES];
+    HYPSampleCollectionViewController *controller = [self controller];
+
+    HYPFormField *firstNameField = [controller.formsManager fieldWithID:@"first_name" includingHiddenFields:YES];
     XCTAssertNotNil(firstNameField);
 
     firstNameField.fieldValue = @"John";
     XCTAssertNotNil(firstNameField.fieldValue);
 
     HYPFormTarget *clearTarget = [HYPFormTarget clearFieldTargetWithID:@"first_name"];
-    [self.dataSource processTarget:clearTarget];
+    [controller.dataSource processTarget:clearTarget];
     XCTAssertNil(firstNameField.fieldValue);
 }
 

--- a/Demo/HYPFormsTests/HYPFormsCollectionViewDataSourceTests.m
+++ b/Demo/HYPFormsTests/HYPFormsCollectionViewDataSourceTests.m
@@ -12,7 +12,7 @@
 
 #import "NSJSONSerialization+ANDYJSONFile.h"
 
-@interface HYPFormsCollectionViewDataSourceTests : XCTestCase <HYPFormsCollectionViewDataSourceDataSource>
+@interface HYPFormsCollectionViewDataSourceTests : XCTestCase
 
 @property (nonatomic, strong) HYPFormsManager *manager;
 @property (nonatomic, strong) HYPFormsCollectionViewDataSource *dataSource;
@@ -42,10 +42,17 @@
 
     self.dataSource = [[HYPFormsCollectionViewDataSource alloc] initWithCollectionView:collectionView
                                                                        andFormsManager:self.manager];
-
-    collectionView.dataSource = self.dataSource;
     layout.dataSource = self.dataSource;
-    self.dataSource.dataSource = self;
+
+    self.dataSource.configureCellForIndexPath = ^(HYPFormField *field, UICollectionView *collectionView, NSIndexPath *indexPath) {
+        BOOL isImageCell = (field.type == HYPFormFieldTypeCustom && [field.typeString isEqual:@"image"]);
+        id cell;
+        if (isImageCell) {
+            cell = [collectionView dequeueReusableCellWithReuseIdentifier:HYPImageFormFieldCellIdentifier
+                                                             forIndexPath:indexPath];
+        }
+        return cell;
+    };
 }
 
 - (void)tearDown
@@ -172,23 +179,6 @@
     HYPFormTarget *clearTarget = [HYPFormTarget clearFieldTargetWithID:@"first_name"];
     [self.dataSource processTarget:clearTarget];
     XCTAssertNil(firstNameField.fieldValue);
-}
-
-#pragma mark - HYPFormsCollectionViewDataSourceDataSource
-
-- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
-               formsCollectionDataSource:(HYPFormsCollectionViewDataSource *)formsCollectionDataSource
-                            cellForField:(HYPFormField *)field atIndexPath:(NSIndexPath *)indexPath
-{
-    HYPImageFormFieldCell *cell;
-
-    BOOL isImageCell = (field.type == HYPFormFieldTypeCustom && [field.typeString isEqual:@"image"]);
-    if (isImageCell) {
-        cell = [collectionView dequeueReusableCellWithReuseIdentifier:HYPImageFormFieldCellIdentifier
-                                                         forIndexPath:indexPath];
-    }
-
-    return cell;
 }
 
 @end

--- a/Demo/HYPFormsTests/HYPFormsCollectionViewDataSourceTests.m
+++ b/Demo/HYPFormsTests/HYPFormsCollectionViewDataSourceTests.m
@@ -16,7 +16,6 @@
 @interface HYPSampleCollectionViewController ()
 
 @property (nonatomic, strong) HYPFormsCollectionViewDataSource *dataSource;
-@property (nonatomic, strong) HYPFormsManager *formsManager;
 
 @end
 
@@ -39,22 +38,22 @@
 
     [controller.dataSource processTarget:[HYPFormTarget hideFieldTargetWithID:@"display_name"]];
     [controller.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"display_name"]];
-    HYPFormField *field = [controller.formsManager fieldWithID:@"display_name" includingHiddenFields:YES];
-    NSUInteger index = [field indexInSectionUsingForms:controller.formsManager.forms];
+    HYPFormField *field = [controller.dataSource.formsManager fieldWithID:@"display_name" includingHiddenFields:YES];
+    NSUInteger index = [field indexInSectionUsingForms:controller.dataSource.formsManager.forms];
     XCTAssertEqual(index, 2);
 
     [controller.dataSource processTarget:[HYPFormTarget hideFieldTargetWithID:@"username"]];
     [controller.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"username"]];
-    field = [controller.formsManager fieldWithID:@"username" includingHiddenFields:YES];
-    index = [field indexInSectionUsingForms:controller.formsManager.forms];
+    field = [controller.dataSource.formsManager fieldWithID:@"username" includingHiddenFields:YES];
+    index = [field indexInSectionUsingForms:controller.dataSource.formsManager.forms];
     XCTAssertEqual(index, 2);
 
     [controller.dataSource processTargets:[HYPFormTarget hideFieldTargetsWithIDs:@[@"first_name",
                                                                              @"address",
                                                                              @"username"]]];
     [controller.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"username"]];
-    field = [controller.formsManager fieldWithID:@"username" includingHiddenFields:YES];
-    index = [field indexInSectionUsingForms:controller.formsManager.forms];
+    field = [controller.dataSource.formsManager fieldWithID:@"username" includingHiddenFields:YES];
+    index = [field indexInSectionUsingForms:controller.dataSource.formsManager.forms];
     XCTAssertEqual(index, 1);
     [controller.dataSource processTargets:[HYPFormTarget showFieldTargetsWithIDs:@[@"first_name",
                                                                              @"address"]]];
@@ -62,8 +61,8 @@
     [controller.dataSource processTargets:[HYPFormTarget hideFieldTargetsWithIDs:@[@"last_name",
                                                                              @"address"]]];
     [controller.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"address"]];
-    field = [controller.formsManager fieldWithID:@"address" includingHiddenFields:YES];
-    index = [field indexInSectionUsingForms:controller.formsManager.forms];
+    field = [controller.dataSource.formsManager fieldWithID:@"address" includingHiddenFields:YES];
+    index = [field indexInSectionUsingForms:controller.dataSource.formsManager.forms];
     XCTAssertEqual(index, 0);
     [controller.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"last_name"]];
 }
@@ -73,7 +72,7 @@
     HYPSampleCollectionViewController *controller = [self controller];
     [controller.dataSource enable];
 
-    HYPFormField *targetField = [controller.formsManager fieldWithID:@"base_salary" includingHiddenFields:YES];
+    HYPFormField *targetField = [controller.dataSource.formsManager fieldWithID:@"base_salary" includingHiddenFields:YES];
     XCTAssertFalse(targetField.isDisabled);
 
     HYPFormTarget *disableTarget = [HYPFormTarget disableFieldTargetWithID:@"base_salary"];
@@ -95,7 +94,7 @@
 {
     HYPSampleCollectionViewController *controller = [self controller];
 
-    HYPFormField *totalField = [controller.formsManager fieldWithID:@"total" includingHiddenFields:YES];
+    HYPFormField *totalField = [controller.dataSource.formsManager fieldWithID:@"total" includingHiddenFields:YES];
     XCTAssertTrue(totalField.disabled);
 }
 
@@ -103,7 +102,7 @@
 {
     HYPSampleCollectionViewController *controller = [self controller];
 
-    HYPFormField *targetField = [controller.formsManager fieldWithID:@"display_name" includingHiddenFields:YES];
+    HYPFormField *targetField = [controller.dataSource.formsManager fieldWithID:@"display_name" includingHiddenFields:YES];
     XCTAssertNil(targetField.fieldValue);
 
     HYPFormTarget *updateTarget = [HYPFormTarget updateFieldTargetWithID:@"display_name"];
@@ -117,7 +116,7 @@
 {
     HYPSampleCollectionViewController *controller = [self controller];
 
-    HYPFormField *usernameField = [controller.formsManager fieldWithID:@"username" includingHiddenFields:YES];
+    HYPFormField *usernameField = [controller.dataSource.formsManager fieldWithID:@"username" includingHiddenFields:YES];
     XCTAssertNotNil(usernameField.fieldValue);
 }
 
@@ -125,8 +124,8 @@
 {
     HYPSampleCollectionViewController *controller = [self controller];
 
-    HYPFormField *displayNameField = [controller.formsManager fieldWithID:@"display_name" includingHiddenFields:YES];
-    HYPFormField *usernameField = [controller.formsManager fieldWithID:@"username" includingHiddenFields:YES];
+    HYPFormField *displayNameField = [controller.dataSource.formsManager fieldWithID:@"display_name" includingHiddenFields:YES];
+    HYPFormField *usernameField = [controller.dataSource.formsManager fieldWithID:@"username" includingHiddenFields:YES];
     HYPFieldValue *fieldValue = usernameField.fieldValue;
     XCTAssertEqualObjects(fieldValue.valueID, @0);
 
@@ -149,7 +148,7 @@
     [controller.dataSource reloadWithDictionary:@{@"first_name" : @"Elvis",
                                             @"last_name" : @"Nunez"}];
 
-    HYPFormField *field = [controller.formsManager fieldWithID:@"display_name" includingHiddenFields:YES];
+    HYPFormField *field = [controller.dataSource.formsManager fieldWithID:@"display_name" includingHiddenFields:YES];
     XCTAssertEqualObjects(field.fieldValue, @"Elvis Nunez");
 }
 
@@ -157,7 +156,7 @@
 {
     HYPSampleCollectionViewController *controller = [self controller];
 
-    HYPFormField *firstNameField = [controller.formsManager fieldWithID:@"first_name" includingHiddenFields:YES];
+    HYPFormField *firstNameField = [controller.dataSource.formsManager fieldWithID:@"first_name" includingHiddenFields:YES];
     XCTAssertNotNil(firstNameField);
 
     firstNameField.fieldValue = @"John";

--- a/Demo/HYPFormsTests/HYPFormsCollectionViewDataSourceTests.m
+++ b/Demo/HYPFormsTests/HYPFormsCollectionViewDataSourceTests.m
@@ -8,10 +8,11 @@
 #import "HYPFormSection.h"
 #import "HYPFormsManager.h"
 #import "HYPFormTarget.h"
+#import "HYPImageFormFieldCell.h"
 
 #import "NSJSONSerialization+ANDYJSONFile.h"
 
-@interface HYPFormsCollectionViewDataSourceTests : XCTestCase <HYPFormsLayoutDataSource>
+@interface HYPFormsCollectionViewDataSourceTests : XCTestCase <HYPFormsCollectionViewDataSourceDataSource>
 
 @property (nonatomic, strong) HYPFormsManager *manager;
 @property (nonatomic, strong) HYPFormsCollectionViewDataSource *dataSource;
@@ -25,10 +26,12 @@
     [super setUp];
 
     HYPFormsLayout *layout = [[HYPFormsLayout alloc] init];
-    layout.dataSource = self;
 
     UICollectionView *collectionView = [[UICollectionView alloc] initWithFrame:[[UIScreen mainScreen] bounds]
                                                           collectionViewLayout:layout];
+
+    [collectionView registerClass:[HYPImageFormFieldCell class]
+       forCellWithReuseIdentifier:HYPImageFormFieldCellIdentifier];
 
     NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"forms.json"];
 
@@ -39,6 +42,10 @@
 
     self.dataSource = [[HYPFormsCollectionViewDataSource alloc] initWithCollectionView:collectionView
                                                                        andFormsManager:self.manager];
+
+    collectionView.dataSource = self.dataSource;
+    layout.dataSource = self.dataSource;
+    self.dataSource.dataSource = self;
 }
 
 - (void)tearDown
@@ -167,16 +174,21 @@
     XCTAssertNil(firstNameField.fieldValue);
 }
 
-#pragma mark - HYPFormsLayoutDataSource
+#pragma mark - HYPFormsCollectionViewDataSourceDataSource
 
-- (NSArray *)forms
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
+               formsCollectionDataSource:(HYPFormsCollectionViewDataSource *)formsCollectionDataSource
+                            cellForField:(HYPFormField *)field atIndexPath:(NSIndexPath *)indexPath
 {
-    return self.manager.forms;
-}
+    HYPImageFormFieldCell *cell;
 
-- (NSArray *)collapsedForms
-{
-    return self.dataSource.collapsedForms;
+    BOOL isImageCell = (field.type == HYPFormFieldTypeCustom && [field.typeString isEqual:@"image"]);
+    if (isImageCell) {
+        cell = [collectionView dequeueReusableCellWithReuseIdentifier:HYPImageFormFieldCellIdentifier
+                                                         forIndexPath:indexPath];
+    }
+
+    return cell;
 }
 
 @end

--- a/Demo/HYPFormsTests/HYPFormsManagerTests.m
+++ b/Demo/HYPFormsTests/HYPFormsManagerTests.m
@@ -14,9 +14,6 @@
 
 @interface HYPFormsManagerTests : XCTestCase
 
-@property (nonatomic, strong) HYPFormsManager *manager;
-@property (nonatomic, strong) HYPFormsCollectionViewDataSource *dataSource;
-
 @end
 
 @implementation HYPFormsManagerTests
@@ -127,27 +124,33 @@
 {
     NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"forms.json"];
 
-    HYPFormsManager *manager = [[HYPFormsManager alloc] initWithJSON:JSON
-                                                       initialValues:@{@"first_name" : @"Elvis",
-                                                                       @"last_name" : @"Nunez"}
-                                                    disabledFieldIDs:nil
-                                                            disabled:NO];
+    HYPFormsCollectionViewDataSource *dataSource = [[HYPFormsCollectionViewDataSource alloc] initWithJSON:JSON
+                                                                                           collectionView:nil
+                                                                                                   layout:nil
+                                                                                                   values:@{@"first_name" : @"Elvis",
+                                                                                                            @"last_name" : @"Nunez"}];
+    [dataSource enable];
 
-    HYPFormField *firstNameField = [manager fieldWithID:@"first_name" includingHiddenFields:NO];
+    HYPFormField *firstNameField = [dataSource.formsManager fieldWithID:@"first_name" includingHiddenFields:NO];
     XCTAssertNotNil(firstNameField);
     XCTAssertEqualObjects(firstNameField.fieldID, @"first_name");
+    XCTAssertEqualObjects(firstNameField.fieldValue, @"Elvis");
 
-    [self.dataSource processTarget:[HYPFormTarget hideFieldTargetWithID:@"start_date"]];
-    HYPFormField *startDateField = [manager fieldWithID:@"start_date" includingHiddenFields:NO];
+    HYPFormField *startDateField = [dataSource.formsManager fieldWithID:@"start_date" includingHiddenFields:NO];
     XCTAssertNotNil(startDateField);
     XCTAssertEqualObjects(startDateField.fieldID, @"start_date");
-    [self.dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"start_date"]];
+    [dataSource processTarget:[HYPFormTarget hideFieldTargetWithID:@"start_date"]];
+    startDateField = [dataSource.formsManager fieldWithID:@"start_date" includingHiddenFields:NO];
+    XCTAssertNil(startDateField);
+    [dataSource processTarget:[HYPFormTarget showFieldTargetWithID:@"start_date"]];
+    startDateField = [dataSource.formsManager fieldWithID:@"start_date" includingHiddenFields:NO];
+    XCTAssertNotNil(startDateField);
 
-    [self.dataSource processTarget:[HYPFormTarget hideSectionTargetWithID:@"employment-1"]];
-    HYPFormField *contractTypeField = [manager fieldWithID:@"contract_type" includingHiddenFields:NO];
+    [dataSource processTarget:[HYPFormTarget hideSectionTargetWithID:@"employment-1"]];
+    HYPFormField *contractTypeField = [dataSource.formsManager fieldWithID:@"contract_type" includingHiddenFields:NO];
     XCTAssertNotNil(contractTypeField);
     XCTAssertEqualObjects(contractTypeField.fieldID, @"contract_type");
-    [self.dataSource processTarget:[HYPFormTarget showSectionTargetWithID:@"employment-1"]];
+    [dataSource processTarget:[HYPFormTarget showSectionTargetWithID:@"employment-1"]];
 }
 
 - (void)testShowingFieldMultipleTimes

--- a/Demo/HYPFormsTests/HYPFormsManagerTests.m
+++ b/Demo/HYPFormsTests/HYPFormsManagerTests.m
@@ -128,8 +128,8 @@
                                                                                            collectionView:nil
                                                                                                    layout:nil
                                                                                                    values:@{@"first_name" : @"Elvis",
-                                                                                                            @"last_name" : @"Nunez"}];
-    [dataSource enable];
+                                                                                                            @"last_name" : @"Nunez"}
+                                                                                                 disabled:NO];
 
     HYPFormField *firstNameField = [dataSource.formsManager fieldWithID:@"first_name" includingHiddenFields:NO];
     XCTAssertNotNil(firstNameField);

--- a/HYPForms.podspec
+++ b/HYPForms.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "HYPForms"
-  s.version = "0.108"
+  s.version = "0.109"
   s.summary = "JSON driven forms"
   s.description = <<-DESC
                    * JSON driven forms

--- a/Source/HYPFormsCollectionViewDataSource.h
+++ b/Source/HYPFormsCollectionViewDataSource.h
@@ -19,7 +19,7 @@ typedef void (^HYPFieldConfigureFieldUpdatedBlock)(id cell, HYPFormField *field)
 
 @protocol HYPFormsCollectionViewDataSourceDataSource;
 
-@interface HYPFormsCollectionViewDataSource : NSObject <UICollectionViewDataSource>
+@interface HYPFormsCollectionViewDataSource : NSObject <UICollectionViewDataSource, HYPFormsLayoutDataSource>
 
 - (instancetype)initWithCollectionView:(UICollectionView *)collectionView andFormsManager:(HYPFormsManager *)formsManager;
 

--- a/Source/HYPFormsCollectionViewDataSource.h
+++ b/Source/HYPFormsCollectionViewDataSource.h
@@ -25,7 +25,8 @@ typedef UICollectionViewCell * (^HYPFieldConfigureCellForItemAtIndexPath)(HYPFor
 - (instancetype)initWithJSON:(NSArray *)JSON
               collectionView:(UICollectionView *)collectionView
                       layout:(HYPFormsLayout *)layout
-                      values:(NSDictionary *)values;
+                      values:(NSDictionary *)values
+                     disabled:(BOOL)disabled;
 
 @property (nonatomic, strong) NSMutableArray *collapsedForms;
 @property (nonatomic, strong, readonly) HYPFormsManager *formsManager;

--- a/Source/HYPFormsCollectionViewDataSource.h
+++ b/Source/HYPFormsCollectionViewDataSource.h
@@ -57,7 +57,8 @@ typedef void (^HYPFieldConfigureFieldUpdatedBlock)(id cell, HYPFormField *field)
 
 @protocol HYPFormsCollectionViewDataSourceDataSource <NSObject>
 
-- (UICollectionViewCell *)formsCollectionDataSource:(HYPFormsCollectionViewDataSource *)formsCollectionDataSource
-                                       cellForField:(HYPFormField *)field atIndexPath:(NSIndexPath *)indexPath;
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
+               formsCollectionDataSource:(HYPFormsCollectionViewDataSource *)formsCollectionDataSource
+                            cellForField:(HYPFormField *)field atIndexPath:(NSIndexPath *)indexPath;
 
 @end

--- a/Source/HYPFormsCollectionViewDataSource.h
+++ b/Source/HYPFormsCollectionViewDataSource.h
@@ -22,11 +22,13 @@ typedef UICollectionViewCell * (^HYPFieldConfigureCellForItemAtIndexPath)(HYPFor
 
 @interface HYPFormsCollectionViewDataSource : NSObject <UICollectionViewDataSource, HYPFormsLayoutDataSource>
 
-- (instancetype)initWithCollectionView:(UICollectionView *)collectionView
-                                layout:(HYPFormsLayout *)layout
-                       andFormsManager:(HYPFormsManager *)formsManager;
+- (instancetype)initWithJSON:(NSArray *)JSON
+              collectionView:(UICollectionView *)collectionView
+                      layout:(HYPFormsLayout *)layout
+                      values:(NSDictionary *)values;
 
 @property (nonatomic, strong) NSMutableArray *collapsedForms;
+@property (nonatomic, strong, readonly) HYPFormsManager *formsManager;
 
 @property (nonatomic, copy) HYPFieldConfigureCellBlock configureCellBlock;
 @property (nonatomic, copy) HYPFieldConfigureHeaderViewBlock configureHeaderViewBlock;

--- a/Source/HYPFormsCollectionViewDataSource.h
+++ b/Source/HYPFormsCollectionViewDataSource.h
@@ -22,7 +22,9 @@ typedef UICollectionViewCell * (^HYPFieldConfigureCellForItemAtIndexPath)(HYPFor
 
 @interface HYPFormsCollectionViewDataSource : NSObject <UICollectionViewDataSource, HYPFormsLayoutDataSource>
 
-- (instancetype)initWithCollectionView:(UICollectionView *)collectionView andFormsManager:(HYPFormsManager *)formsManager;
+- (instancetype)initWithCollectionView:(UICollectionView *)collectionView
+                                layout:(HYPFormsLayout *)layout
+                       andFormsManager:(HYPFormsManager *)formsManager;
 
 @property (nonatomic, strong) NSMutableArray *collapsedForms;
 

--- a/Source/HYPFormsCollectionViewDataSource.h
+++ b/Source/HYPFormsCollectionViewDataSource.h
@@ -16,6 +16,7 @@
 typedef void (^HYPFieldConfigureCellBlock)(id cell, NSIndexPath *indexPath, HYPFormField *field);
 typedef void (^HYPFieldConfigureHeaderViewBlock)(HYPFormHeaderView *headerView, NSString *kind, NSIndexPath *indexPath, HYPForm *form);
 typedef void (^HYPFieldConfigureFieldUpdatedBlock)(id cell, HYPFormField *field);
+typedef UICollectionViewCell * (^HYPFieldConfigureCellForItemAtIndexPath)(HYPFormField *field, UICollectionView *collectionView, NSIndexPath *indexPath);
 
 @protocol HYPFormsCollectionViewDataSourceDataSource;
 
@@ -28,8 +29,7 @@ typedef void (^HYPFieldConfigureFieldUpdatedBlock)(id cell, HYPFormField *field)
 @property (nonatomic, copy) HYPFieldConfigureCellBlock configureCellBlock;
 @property (nonatomic, copy) HYPFieldConfigureHeaderViewBlock configureHeaderViewBlock;
 @property (nonatomic, copy) HYPFieldConfigureFieldUpdatedBlock configureFieldUpdatedBlock;
-
-@property (nonatomic, weak) id <HYPFormsCollectionViewDataSourceDataSource> dataSource;
+@property (nonatomic, copy) HYPFieldConfigureCellForItemAtIndexPath configureCellForIndexPath;
 
 - (BOOL)formFieldsAreValid;
 - (CGSize)sizeForItemAtIndexPath:(NSIndexPath *)indexPath;
@@ -52,13 +52,5 @@ typedef void (^HYPFieldConfigureFieldUpdatedBlock)(id cell, HYPFormField *field)
 - (void)insertItemsAtIndexPaths:(NSArray *)indexPaths;
 - (void)deleteItemsAtIndexPaths:(NSArray *)indexPaths;
 - (void)reloadItemsAtIndexPaths:(NSArray *)indexPaths;
-
-@end
-
-@protocol HYPFormsCollectionViewDataSourceDataSource <NSObject>
-
-- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
-               formsCollectionDataSource:(HYPFormsCollectionViewDataSource *)formsCollectionDataSource
-                            cellForField:(HYPFormField *)field atIndexPath:(NSIndexPath *)indexPath;
 
 @end

--- a/Source/HYPFormsCollectionViewDataSource.m
+++ b/Source/HYPFormsCollectionViewDataSource.m
@@ -24,6 +24,7 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
 @property (nonatomic) BOOL disabled;
 @property (nonatomic, strong) HYPFormsManager *formsManager;
 @property (nonatomic, strong) UICollectionView *collectionView;
+@property (nonatomic, strong) HYPFormsLayout *layout;
 
 @end
 
@@ -41,6 +42,7 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
 #pragma mark - Initializers
 
 - (instancetype)initWithCollectionView:(UICollectionView *)collectionView
+                                layout:(HYPFormsLayout *)layout
                        andFormsManager:(HYPFormsManager *)formsManager
 {
     self = [super init];
@@ -50,7 +52,11 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
 
     _collectionView = collectionView;
 
+    _layout = layout;
+
     _originalInset = collectionView.contentInset;
+
+    layout.dataSource = self;
 
     [collectionView registerClass:[HYPTextFormFieldCell class]
        forCellWithReuseIdentifier:HYPTextFormFieldCellIdentifier];
@@ -77,10 +83,6 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
                                              selector:@selector(keyboardDidHide:)
                                                  name:UIKeyboardDidHideNotification
                                                object:nil];
-
-    collectionView.dataSource = self;
-
-    NSLog(@"Initializated with %ld sections", (long)[collectionView numberOfSections]);
 
     return self;
 }
@@ -110,7 +112,8 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
         return 0;
     }
 
-    return [form numberOfFields:self.formsManager.hiddenSections];
+    NSInteger numberOfItems = [form numberOfFields:self.formsManager.hiddenSections];
+    return numberOfItems;
 }
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView
@@ -268,11 +271,14 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
     CGFloat width = 0.0f;
     CGFloat height = 0.0f;
 
-    HYPFormField *field = fields[indexPath.row];
+    HYPFormField *field;
+    if (indexPath.row < fields.count) {
+        field = fields[indexPath.row];
+    }
     if (field.sectionSeparator) {
         width = deviceWidth;
         height = HYPFieldCellItemSmallHeight;
-    } else {
+    } else if (field) {
         width = floor(deviceWidth * (field.size.width / 100.0f));
 
         if (field.type == HYPFormFieldTypeCustom) {

--- a/Source/HYPFormsCollectionViewDataSource.m
+++ b/Source/HYPFormsCollectionViewDataSource.m
@@ -117,8 +117,7 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
         return 0;
     }
 
-    NSInteger numberOfItems = [form numberOfFields:self.formsManager.hiddenSections];
-    return numberOfItems;
+    return [form numberOfFields:self.formsManager.hiddenSections];
 }
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView

--- a/Source/HYPFormsCollectionViewDataSource.m
+++ b/Source/HYPFormsCollectionViewDataSource.m
@@ -116,8 +116,8 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
     NSArray *fields = form.fields;
     HYPFormField *field = fields[indexPath.row];
 
-    if ([self.dataSource respondsToSelector:@selector(formsCollectionDataSource:cellForField:atIndexPath:)]) {
-        UICollectionViewCell *cell = [self.dataSource formsCollectionDataSource:self cellForField:field atIndexPath:indexPath];
+    if ([self.dataSource respondsToSelector:@selector(collectionView:formsCollectionDataSource:cellForField:atIndexPath:)]) {
+        UICollectionViewCell *cell = [self.dataSource collectionView:collectionView formsCollectionDataSource:self cellForField:field atIndexPath:indexPath];
         if (cell) return cell;
     }
 

--- a/Source/HYPFormsCollectionViewDataSource.m
+++ b/Source/HYPFormsCollectionViewDataSource.m
@@ -46,6 +46,7 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
               collectionView:(UICollectionView *)collectionView
                       layout:(HYPFormsLayout *)layout
                       values:(NSDictionary *)values
+                    disabled:(BOOL)disabled
 {
     self = [super init];
     if (!self) return nil;
@@ -61,7 +62,7 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
     _formsManager = [[HYPFormsManager alloc] initWithJSON:JSON
                                             initialValues:values
                                          disabledFieldIDs:@[]
-                                                 disabled:YES];
+                                                 disabled:disabled];
 
     [collectionView registerClass:[HYPTextFormFieldCell class]
        forCellWithReuseIdentifier:HYPTextFormFieldCellIdentifier];

--- a/Source/HYPFormsCollectionViewDataSource.m
+++ b/Source/HYPFormsCollectionViewDataSource.m
@@ -78,6 +78,10 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
                                                  name:UIKeyboardDidHideNotification
                                                object:nil];
 
+    collectionView.dataSource = self;
+
+    NSLog(@"Initializated with %ld sections", (long)[collectionView numberOfSections]);
+
     return self;
 }
 
@@ -116,9 +120,9 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
     NSArray *fields = form.fields;
     HYPFormField *field = fields[indexPath.row];
 
-    if ([self.dataSource respondsToSelector:@selector(collectionView:formsCollectionDataSource:cellForField:atIndexPath:)]) {
-        UICollectionViewCell *cell = [self.dataSource collectionView:collectionView formsCollectionDataSource:self cellForField:field atIndexPath:indexPath];
-        if (cell) return cell;
+    if (self.configureCellForIndexPath) {
+        id configuredCell = self.configureCellForIndexPath(field, collectionView, indexPath);
+        if (configuredCell) return configuredCell;
     }
 
     NSString *identifier;

--- a/Source/HYPFormsCollectionViewDataSource.m
+++ b/Source/HYPFormsCollectionViewDataSource.m
@@ -22,9 +22,10 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
 
 @property (nonatomic) UIEdgeInsets originalInset;
 @property (nonatomic) BOOL disabled;
-@property (nonatomic, strong) HYPFormsManager *formsManager;
+@property (nonatomic, strong, readwrite) HYPFormsManager *formsManager;
 @property (nonatomic, strong) UICollectionView *collectionView;
 @property (nonatomic, strong) HYPFormsLayout *layout;
+@property (nonatomic, copy) NSArray *JSON;
 
 @end
 
@@ -41,14 +42,13 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
 
 #pragma mark - Initializers
 
-- (instancetype)initWithCollectionView:(UICollectionView *)collectionView
-                                layout:(HYPFormsLayout *)layout
-                       andFormsManager:(HYPFormsManager *)formsManager
+- (instancetype)initWithJSON:(NSArray *)JSON
+              collectionView:(UICollectionView *)collectionView
+                      layout:(HYPFormsLayout *)layout
+                      values:(NSDictionary *)values
 {
     self = [super init];
     if (!self) return nil;
-
-    _formsManager = formsManager;
 
     _collectionView = collectionView;
 
@@ -57,6 +57,11 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
     _originalInset = collectionView.contentInset;
 
     layout.dataSource = self;
+
+    _formsManager = [[HYPFormsManager alloc] initWithJSON:JSON
+                                            initialValues:values
+                                         disabledFieldIDs:@[]
+                                                 disabled:YES];
 
     [collectionView registerClass:[HYPTextFormFieldCell class]
        forCellWithReuseIdentifier:HYPTextFormFieldCellIdentifier];

--- a/Source/HYPFormsCollectionViewDataSource.m
+++ b/Source/HYPFormsCollectionViewDataSource.m
@@ -18,13 +18,12 @@
 
 static const CGFloat HYPFormsDispatchTime = 0.05f;
 
-@interface HYPFormsCollectionViewDataSource () <HYPBaseFormFieldCellDelegate, HYPFormHeaderViewDelegate
-, UICollectionViewDataSource>
+@interface HYPFormsCollectionViewDataSource () <HYPBaseFormFieldCellDelegate, HYPFormHeaderViewDelegate>
 
-@property (nonatomic, weak) UICollectionView *collectionView;
 @property (nonatomic) UIEdgeInsets originalInset;
 @property (nonatomic) BOOL disabled;
-@property (nonatomic, weak) HYPFormsManager *formsManager;
+@property (nonatomic, strong) HYPFormsManager *formsManager;
+@property (nonatomic, strong) UICollectionView *collectionView;
 
 @end
 
@@ -673,6 +672,13 @@ static const CGFloat HYPFormsDispatchTime = 0.05f;
 - (void)formHeaderViewWasPressed:(HYPFormHeaderView *)headerView
 {
     [self collapseFieldsInSection:headerView.section collectionView:self.collectionView];
+}
+
+#pragma mark - HYPFormsLayoutDataSource
+
+- (NSArray *)forms
+{
+    return self.formsManager.forms;
 }
 
 @end


### PR DESCRIPTION
Before it was a nightmare to initialize and start using HYPForms, now it should be easier

Before you had to hook up delegates, data sources, data sources that had data sources, custom cells where a nightmare ([now is just a block](https://github.com/hyperoslo/HYPForms/blob/simplify-form-delegates/Demo/HYPForms/HYPSampleCollectionViewController.m#L72))
```objc
- (HYPFormsCollectionViewDataSource *)dataSource
{
    if (_dataSource) return _dataSource;

    NSArray *JSON = [NSJSONSerialization JSONObjectWithContentsOfFile:@"forms.json"];

    _dataSource = [[HYPFormsCollectionViewDataSource alloc] initWithJSON:JSON
                                                          collectionView:self.collectionView
                                                                  layout:self.layout
                                                                  values:self.initialValues
                                                                disabled:YES];

    _dataSource.configureCellForIndexPath = ^(HYPFormField *field, UICollectionView *collectionView, NSIndexPath *indexPath) {
        // Return custom cell for field if applies
        // return cell;
    };

    _dataSource.configureFieldUpdatedBlock = ^(id cell, HYPFormField *field) {
        // Field was updated, do something
    };

    return _dataSource;
}
```


**Update**: *Removed the need to create a `formsManager`, this one will be created by the `dataSource` and can be accessed (readonly) doing `dataSource.formsManager`.*

**Update 2**: *Added `disabled` flag.*